### PR TITLE
Add microdata for events - hopefully will improve search results

### DIFF
--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -99,10 +99,17 @@ export default ({
         eventId: id,
       },
     })}
+    itemScope
+    itemType="http://schema.org/Event"
   >
-    <EventCard background={pathToUrl((banner || {}).file_path)}>
-      <Logo src={pathToUrl((logo || {}).file_path)} />
-      <Heading.h3 regular my={2} style={{ flex: '1 0 auto' }}>
+    <EventCard background={pathToUrl((banner || {}).file_path)} >
+      <Logo itemProp="image" src={pathToUrl((logo || {}).file_path)} />
+      <Heading.h3
+        regular
+        my={2}
+        style={{ flex: '1 0 auto' }}
+        itemProp="name"
+      >
         {name}
       </Heading.h3>
       <Flex justify="space-between" w={1}>
@@ -112,16 +119,33 @@ export default ({
             ? `, ${startYear}`
             : null}
         </Text>
-        <Text>
-          {distanceTo
-            ? `${humanizeDistance(distanceTo)} miles`
-            : `${parsed_city}, ${
-                parsed_country_code === 'US'
-                  ? parsed_state_code
-                  : parsed_country
-              }`}
-        </Text>
+        {distanceTo
+            ? (
+              <Text>`${humanizeDistance(distanceTo)} miles`</Text>
+            ) : (
+              <Text
+                itemProp="location"
+                itemScope
+                itemType="http://schema.org/Place"
+              >
+                <span itemProp="address">
+                  {parsed_city}, {
+                    parsed_country_code === 'US'
+                    ? parsed_state_code
+                    : parsed_country
+                  }
+                </span>
+              </Text>
+            )
+        }
       </Flex>
+
+      { /* Include microdata that doesn't easily fit elsewhere */ }
+      <div style={ {display: 'none'} }>
+        <span itemProp="url">{website}</span>
+        <span itemProp="startDate" content={start}>{start}</span>
+        <span itemProp="endDate" content={end}>{end}</span>
+      </div>
     </EventCard>
   </Base>
 )


### PR DESCRIPTION
This PR adds proper microdata to our events, so Google and other search engines can better understand what this site's all about.

Before this PR:

<img width="1497" alt="screen shot 2018-03-19 at 05 15 59" src="https://user-images.githubusercontent.com/992248/37592551-a390ee16-2b34-11e8-9c88-0cecf63ef407.png">

After this PR:

<img width="1497" alt="screen shot 2018-03-19 at 05 16 33" src="https://user-images.githubusercontent.com/992248/37592594-c44e8500-2b34-11e8-9029-15132d71905e.png">

Look at that beautiful metadata. Expanded:

<img width="1497" alt="screen shot 2018-03-19 at 05 16 46" src="https://user-images.githubusercontent.com/992248/37592607-d11d44b0-2b34-11e8-98de-6d2ca6eecc3c.png">

There are a few warnings, but I think we should be good to go - none of them really apply to us.

<img width="664" alt="screen shot 2018-03-19 at 05 16 51" src="https://user-images.githubusercontent.com/992248/37592638-e802756a-2b34-11e8-9673-0f3c5c3a28cb.png">

Test it yourself at https://search.google.com/structured-data/testing-tool/.