### PR TITLE
Add padding to email form container

### DIFF
--- a/src/components/EmailListForm.js
+++ b/src/components/EmailListForm.js
@@ -170,7 +170,7 @@ const FormikForm = withFormik({
 })(InnerForm)
 
 export default props => (
-  <Box align="center" mx="auto" mb={4}>
+  <Box align="center" mx="auto" mb={4} px={3}>
     <FormikForm location={props.location} />
   </Box>
 )


### PR DESCRIPTION
Form will no longer touch the edge of the screen when size is under 48rem wide.

![screenshot](https://user-images.githubusercontent.com/10110245/41254868-9da2379e-6d79-11e8-83dd-d93e6f224acb.png)
