### PR TITLE
Add `webfonts` prop to ThemeProvider

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -12,7 +12,7 @@ const meta = tags =>
   )
 
 const TemplateWrapper = ({ children }) => (
-  <ThemeProvider>
+  <ThemeProvider webfonts>
     <Helmet>
       <title>List of High School Hackathons – Hack Club</title>
       {meta([


### PR DESCRIPTION
This fixes the issue with the Averta font not being used.