### PR TITLE
Lock dep @hackclub/design-system

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "author": "Max Wofford <max@hackclub.com>",
   "dependencies": {
-    "@hackclub/design-system": "^0.0.1-10",
+    "@hackclub/design-system": "0.0.1-10",
     "axios": "^0.19.0",
     "babel-plugin-styled-components": "^1.10.6",
     "formik": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,7 +799,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@hackclub/design-system@^0.0.1-10":
+"@hackclub/design-system@0.0.1-10":
   version "0.0.1-10"
   resolved "https://registry.yarnpkg.com/@hackclub/design-system/-/design-system-0.0.1-10.tgz#4699b71931c4d5670b911852bb5552a18ae3ccc8"
   integrity sha1-Rpm3GTHE1WcLkRhSu1VSoYrjzMg=


### PR DESCRIPTION
Upgrading this dep breaks the site and I wasn't able to quickly figure it out. Let's lock it down until we can figure it out, to prevent breakage when running `yarn upgrade`.

Also, it seems that `@hackclub/design-system` has many commits on `master` that haven't made it into the npm release yet. Even pointing to the latest version on `master` yields a site which looks very wrong. We should investigate this.