### PR TITLE
accessibility: Fix color contrast (100% accessibility score)

### DIFF
--- a/src/components/EmailListForm.js
+++ b/src/components/EmailListForm.js
@@ -96,7 +96,7 @@ const InnerForm = ({
     <Heading.h2 f={3} color="black" mt={1} mb={1}>
       Want to hear when events are added in your area?
     </Heading.h2>
-    <Text f={2} color="muted" mb={2}>
+    <Text f={2} color="slate" mb={2}>
       Join thousands of subscribers from {values.stats.cities} cities +{' '}
       {values.stats.countries} countries.
     </Text>


### PR DESCRIPTION
Background and foreground colors do not have a sufficient contrast ratio. Low-contrast text is difficult or impossible for many users to read.

Lighthouse Before:

<img width="157" alt="Screen Shot 2019-12-22 at 8 56 17 PM" src="https://user-images.githubusercontent.com/121766/71336782-85e62600-24fd-11ea-9c14-9c70e7c30787.png">

After:

<img width="155" alt="Screen Shot 2019-12-22 at 8 56 21 PM" src="https://user-images.githubusercontent.com/121766/71336790-8aaada00-24fd-11ea-9f04-173c2b372364.png">
